### PR TITLE
few fixes (#530)

### DIFF
--- a/res/xml/notification_manager_settings.xml
+++ b/res/xml/notification_manager_settings.xml
@@ -25,12 +25,6 @@
             android:title="@string/heads_up_notifications"
             android:fragment="com.android.settings.headsup.HeadsUpSettings" />
 
-    <!-- Battery fully charged notification -->
-    <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
-        android:key="battery_fully_charged_notification"
-        android:title="@string/battery_fully_charged_notif_title"
-        android:summary="@string/battery_fully_charged_notif_summary" />
-
     <!-- Zen Mode -->
     <PreferenceScreen
             android:key="zen_mode"

--- a/src/com/android/settings/ApnSettings.java
+++ b/src/com/android/settings/ApnSettings.java
@@ -162,12 +162,12 @@ public class ApnSettings extends SettingsPreferenceFragment implements
         final Activity activity = getActivity();
         final int subId = activity.getIntent().getIntExtra(SUB_ID,
                 SubscriptionManager.INVALID_SUBSCRIPTION_ID);
+        TelephonyManager tm = (TelephonyManager)this.getSystemService(Context.TELEPHONY_SERVICE);
 
         mImsi = activity.getIntent().getStringExtra(EXTRA_IMSI);
         if (mImsi == null) {
-            mImsi = "";
+            mImsi = tm.getSubscriberId();
         }
-
         mUm = (UserManager) getSystemService(Context.USER_SERVICE);
 
         mMobileStateFilter = new IntentFilter(

--- a/src/com/android/settings/ButtonSettings.java
+++ b/src/com/android/settings/ButtonSettings.java
@@ -541,6 +541,7 @@ public class ButtonSettings extends SettingsPreferenceFragment implements
             boolean value = (Boolean) newValue;
             Settings.System.putInt(getContentResolver(),
                    Settings.System.ANSWER_VOLUME_BUTTON_BEHAVIOR_ANSWER, value ? 1 : 0);
+            return true;    
         } else if (preference == mCameraDoubleTapPowerGesture) {
             boolean value = (Boolean) newValue;
             Settings.Secure.putInt(getContentResolver(), CAMERA_DOUBLE_TAP_POWER_GESTURE_DISABLED,


### PR DESCRIPTION
* Settings: Use TelephonyManager Context to fix imsi "null" in some case

In some device it is "null"  while imsi code recived from GsmUmtsOptions.
in this case we should use TelephonyManager's getSubcriberID() to re-try.

This commit is based on e6ba33a64dcfeaceb003ec46fcbf70c943cc2c72

After this correction,it works well.as log below:

I insert logcat before and after "if (mImsi == null)"

06-14 13:02:35.716  2511  2511 D ApnSettings: ZJL TEST mImsi Before null
06-14 13:02:35.724  2511  2511 D ApnSettings: ZJL TEST mImsi After 460110413167754

Change-Id: I78719544434b5918ceaa288265d6775d5408004e

* Fix updation of use volume key to answer when selected

*  remove "Battery fully charged notification" switch from notifiaction tab

it is already there in display tab

Signed-off-by: sayeed99 <sayeed.afridi2009@gmail.com>